### PR TITLE
fixed bug in input validation

### DIFF
--- a/scripts/visualize.py
+++ b/scripts/visualize.py
@@ -58,7 +58,7 @@ def voxel2obj(filename, pred, threshold=.3):
     write_obj(filename, verts, faces)
 
 
-if len(sys.argv) <1:
+if len(sys.argv) < 2:
     print('you need to specify what set of voxels to use')
 models = np.load(sys.argv[1])
 print models.shape


### PR DESCRIPTION
length of sys.argv is always greater than 1 when a script is called like `python visualize.py`, with the first entry being "visualize.py" . we need to check if it is less than 2 to check if additional parameters are submitted.